### PR TITLE
introduce support for sc2 soc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 #	Meson DVB drivers
 
-obj-$(CONFIG_MESON_DVB) += dvb_meson.o aml_fe.o
+obj-$(CONFIG_MESON_DVB) += dvb_meson.o aml_fe.o aml_dvb_extern_wrappers.o
 
 dvb_meson-objs = meson_fe.o avl6211.o mn88436.o cxd2841er_wetek.o ascot3.o mxl603.o mxl608.o avl6862.o r912.o tuner_ftm4862.o rda5815m.o
 aml_fe-objs    = aml_dvb.o aml_dmx.o 

--- a/aml_dvb_extern_wrappers.c
+++ b/aml_dvb_extern_wrappers.c
@@ -1,0 +1,106 @@
+/*
+ * Demod driver wrappers for aml_dvb_extern module
+ *
+ * Copyright (C) 2025 Marek Czerski <ma.czerski@gmail.com>
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License along
+ *    with this program; if not, write to the Free Software Foundation, Inc.,
+ *    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <linux/amlogic/aml_demod_common.h>
+#include <linux/amlogic/aml_tuner.h>
+#include "avl6862.h"
+#include "mxl603.h"
+
+struct dvb_frontend *aml_avl68xx_attach(const struct demod_config *cfg)
+{
+	struct avl6862_config avl68xxcfg = {
+		.demod_address = cfg->i2c_addr,
+		.dual_tuner = cfg->tuner1.id != AM_TUNER_NONE ? 1 : 0,
+		.ts_serial = cfg->ts_out_mode ? 0 : 1, /* ts_out_mode: serial or parallel; 0: serial, 1: parallel. */
+		.gpio_lock_led = 0,
+	};
+
+	struct dvb_frontend *fe = avl6862_attach(&avl68xxcfg, cfg->i2c_adap);
+	if (IS_ERR_OR_NULL(fe))
+		return NULL;
+
+	if (cfg->tuner0.id != AM_TUNER_NONE) {
+		const struct tuner_module * tuner = aml_get_tuner_module(cfg->tuner0.id);
+		if (tuner->attach(tuner, fe, &cfg->tuner0) == NULL) {
+			pr_err("AVL68xx: failed to attach tuner0 %s\n", tuner->name);
+		}
+	}
+	else {
+		pr_err("AVL68xx: Missing tuner0 config\n");
+	}
+
+	if (cfg->tuner1.id != AM_TUNER_NONE) {
+		pr_err("AVL68xx: failed to attach tuner1, dual tuner not supported\n");
+	}
+
+	return fe;
+}
+
+struct dvb_frontend *aml_mxl603_attach(struct dvb_frontend *fe,
+				       const struct tuner_config *cfg)
+{
+	struct mxl603_config mxl603cfg = {
+		.xtal_freq_hz = cfg->xtal, /* XTAL Frequency, 0: 16MHz; 1: 24MHz */
+		.if_freq_hz = cfg->if_hz, /* 0  = 3.65MHz
+									 1  = 4MHz
+									 2  = 4.1MHz
+									 3  = 4.15MHz
+									 4  = 4.5MHz
+									 5  = 4.57MHz
+									 6  = 5MHz
+									 7  = 5.38MHz
+									 8  = 6MHz
+									 9  = 6.28MHz
+									 10 = 7.2MHz
+									 11 = 8.25MHz
+									 12 = 35.25MHz
+									 13 = 36MHz
+									 14 = 36.15MHz
+									 15 = 36.65MHz
+									 16 = 44MHz */
+		.agc_type = cfg->if_agc, /* AGC mode selection, self (0) or closed loop (1) */
+		.xtal_cap = cfg->xtal_cap, /* XTAL capacity, 1 LSB = 1pF, maximum is 31pF */
+		.gain_level = cfg->if_amp, /* IF out gain level */
+		.if_out_gain_level = 11, /* IF out gain level (only for terrestial) */
+		.agc_set_point = 66, /* AGC attack point set value */
+		.agc_invert_pol = 0, /* Config AGC Polarity inversion */
+		.invert_if = cfg->if_invert, /* IF spectrum is inverted or not */
+		.loop_thru_enable = cfg->lt_out, /* Loop-Through enable */
+		.clk_out_enable = 1, /* enable or disable clock out */
+		.clk_out_div = 0, /* indicate if XTAL frequency is dived by 4 or not */
+		.clk_out_ext = 0, /* enable or disable external clock out */
+		.xtal_sharing_mode = cfg->xtal_mode, /* XTAL sharing mode. default Master, MXL608_ENABLE to config Slave mode */
+		.single_supply_3_3V = cfg->dual_power ? 0 : 1, /* dual_power: 0: 3.3v, 1: 1.8v and 3.3v. */
+	};
+	return mxl603_attach(fe, cfg->i2c_adap, cfg->i2c_addr, &mxl603cfg);
+}
+
+static int __init aml_dvb_extern_wrappers_init(void)
+{
+	demod_attach_register_cb(AM_DTV_DEMOD_AVL68xx, aml_avl68xx_attach);
+	tuner_attach_register_cb(AM_TUNER_MXL603, aml_mxl603_attach);
+	return 0;
+}
+
+module_init(aml_dvb_extern_wrappers_init);
+
+MODULE_DESCRIPTION("DVB demodulator driver wrappers for aml_dvb_extern module");
+MODULE_AUTHOR("Marek Czerski (ma.czerski@gmail.com)");
+MODULE_LICENSE("GPL");

--- a/avl6862.c
+++ b/avl6862.c
@@ -1806,13 +1806,14 @@ struct dvb_frontend *avl6862_attach(struct avl6862_config *config,
 	if (priv == NULL)
 		goto err;
 
-        if (config->tuner_address)
+        if (config->dual_tuner)
 		memcpy(&priv->frontend.ops, &avl6862_ops, sizeof(struct dvb_frontend_ops));
         else
 		memcpy(&priv->frontend.ops, &avl6762_ops, sizeof(struct dvb_frontend_ops));
 
 	priv->frontend.demodulator_priv = priv;
-	priv->config = config;
+	memcpy(&priv->_cfg, config, sizeof(priv->_cfg));
+	priv->config = &priv->_cfg;
 	priv->i2c = i2c;
 	priv->g_nChannel_ts_total = 0,
 	priv->delivery_system = -1;
@@ -1841,7 +1842,7 @@ struct dvb_frontend *avl6862_attach(struct avl6862_config *config,
 	dev_info(&priv->i2c->dev, "%s: found AVL%d " \
 				"family_id=0x%x", KBUILD_MODNAME, id, fid);
 
-        if (config->tuner_address) {
+        if (config->dual_tuner) {
 		if (!avl6862_set_dvbmode(&priv->frontend, SYS_DVBS))
 		    return &priv->frontend;
 	} 

--- a/avl6862.h
+++ b/avl6862.h
@@ -24,6 +24,16 @@
 
 #define MAX_CHANNEL_INFO 256
 
+struct avl6862_config {
+	int		i2c_id;        // i2c adapter id
+	void		*i2c_adapter;  // i2c adapter
+	u8		demod_address; // demodulator i2c address
+	u8		dual_tuner; // 0: single tuner, 1: dual tuner
+	unsigned char 	eDiseqcStatus;
+	int             ts_serial;
+	int		gpio_lock_led;
+};
+
 struct avl6862_priv {
 	struct i2c_adapter *i2c;
  	struct avl6862_config *config;
@@ -32,16 +42,9 @@ struct avl6862_priv {
 
 	/* DVB-Tx */
 	u16 g_nChannel_ts_total;
-};
 
-struct avl6862_config {
-	int		i2c_id;        // i2c adapter id
-	void		*i2c_adapter;  // i2c adapter
-	u8		demod_address; // demodulator i2c address
-	u8		tuner_address; // tuner i2c address
-	unsigned char 	eDiseqcStatus;
-	int             ts_serial;
-	int		gpio_lock_led;
+	/* Copy of the config provided to the mxl603_attach */
+	struct avl6862_config _cfg;
 };
 
 extern struct dvb_frontend *avl6862_attach(struct avl6862_config *config, struct i2c_adapter *i2c);

--- a/meson_fe.c
+++ b/meson_fe.c
@@ -43,12 +43,12 @@ static struct r912_config r912cfg = {
 };
 static struct avl6862_config avl6862cfg = {
 	.demod_address = 0x14,
-	.tuner_address = 0x7A,
+	.dual_tuner = 1,
 	.ts_serial = 0,
 };
 static struct avl6862_config avl6762cfg = {
 	.demod_address = 0x14,
-	.tuner_address = 0,
+	.dual_tuner = 0,
 	.ts_serial = 0,
 };
 static struct cxd2841er_config cxd2841cfg = {

--- a/mxl603.c
+++ b/mxl603.c
@@ -151,6 +151,9 @@ struct mxl603_state {
 	u8 addr;
 	u32 frequency;
 	u32 bandwidth;
+
+	/* Copy of the config provided to the mxl603_attach */
+	struct mxl603_config _cfg;
 };
 
 static int mxl603_write_reg(struct mxl603_state *state, u8 reg, u8 val)
@@ -1059,7 +1062,8 @@ struct dvb_frontend *mxl603_attach(struct dvb_frontend *fe,
 		goto err1;
 	}
 	
-	state->config = config;
+	memcpy(&state->_cfg, config, sizeof(state->_cfg));
+	state->config = &state->_cfg;
 	state->i2c = i2c;
 	state->addr = addr;
 	


### PR DESCRIPTION
new module aml_dvb_extern_wrappers registers attach functions of demodulators and tuners for use by AMLOGIC_DVB_EXTERN